### PR TITLE
Issue with deleting fields for static attribute fieldsets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# PyCharm project settins
+.idea

--- a/README.rst
+++ b/README.rst
@@ -66,6 +66,14 @@ Use class ``FieldPermissionMixin`` and set permissions using ``fields_permission
             'articles.can_change_admin_seo_fields': ('seo_title', 'seo_description'),
         }
 
+    # in articles/models.py:
+    class Article(models.Model):
+        class Meta:
+            permissions = (
+                ('can_change_admin_seo_fields', _('Show SEO fields')),
+            )
+
+Then run makemigrations to add all the permissions in your database
 
 Options
 ~~~~~~~

--- a/admin_permissions/admin.py
+++ b/admin_permissions/admin.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 from __future__ import unicode_literals
+from copy import deepcopy
 
 
 class FieldPermissionMixin(object):
@@ -12,6 +13,9 @@ class FieldPermissionMixin(object):
         fieldsets = super(FieldPermissionMixin, self).get_fieldsets(request, obj)
 
         if not self.fields_permissions_read_only:
+            # if formset was received by link we should make copy before removing fields
+            if getattr(self, 'fieldsets', None) is fieldsets:
+                fieldsets = deepcopy(fieldsets)
             for permission, fields in self.fields_permissions.items():
                 if not request.user.has_perm(permission):
                     if isinstance(fields, (str, list)):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,12 +3,14 @@
 from __future__ import unicode_literals
 
 import unittest
+from unittest.mock import MagicMock
 
 from admin_permissions.admin import FieldPermissionMixin
 
 
 class AdminPermissionTest(unittest.TestCase):
     def setUp(self):
+        self.fields_permissions_read_only = False
         self.fieldsets = [
             ('General', {
                 'fields': ['title', 'slug', 'preview_content', 'content', 'public'],
@@ -25,3 +27,25 @@ class AdminPermissionTest(unittest.TestCase):
     def test_remove_fields_and_empty_fieldsets(self):
         fieldsets = FieldPermissionMixin.remove_fields(self.fieldsets, 'seo_title', 'seo_description')
         self.assertListEqual([('General', {'fields': ['title', 'slug', 'preview_content', 'content', 'public']})], fieldsets)
+
+    def test_unchanging_base_fieldset(self):
+        class BaseAdmin(object):
+            fieldsets = None
+
+            def get_fieldsets(self, request, obj):
+                return self.fieldsets
+
+        class AdminTest(FieldPermissionMixin, BaseAdmin):
+            fieldsets = self.fieldsets
+            fields_permissions = {
+                'articles.can_change_admin_base_fields': ('title', 'slug', 'preview_content', 'content', 'public'),
+                'articles.can_change_admin_seo_fields': ('seo_title', 'seo_description'),
+            }
+
+        request = MagicMock(user=MagicMock(has_perm=MagicMock(return_value=False)))
+        admin_instance = AdminTest()
+        fieldsets = admin_instance.get_fieldsets(request, None)
+        self.assertListEqual([], fieldsets)
+        self.assertEqual(len(admin_instance.fieldsets), 2)
+        self.assertListEqual(['title', 'slug', 'preview_content', 'content', 'public'], admin_instance.fieldsets[0][1]['fields'])
+        self.assertListEqual(['seo_title', 'seo_description'], admin_instance.fieldsets[1][1]['fields'])


### PR DESCRIPTION
After the removing fields for specific role - this fields also will never shown for users who have permission for this fileds, when filedsets is a static attribute (like in docs for example)